### PR TITLE
Resolve lost configuration changes (Fixes #2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@
 FROM alpine:latest
 
 RUN ARCHITECTURE=linux_x64                                                                    && \
-    SHA256_DUPLICACY=162ecb3ea14ee28b2dccb3342f0446eab3bb0154cc7cadfb794551e81eb56cda         && \
-    SHA256_DUPLICACY_WEB=9381581171503788a9c31c60ea672bf0a0f3fc7d7537f83c24b318fef009b87f     && \
-    VERSION_DUPLICACY=2.4.0                                                                   && \
-    VERSION_DUPLICACY_WEB=1.2.1                                                               && \
+    SHA256_DUPLICACY=b83c2c8095839f00b7851967615e81ca4fbd4d255b4bfde9da9ba74ff85a852d         && \
+    SHA256_DUPLICACY_WEB=7e20fefb806578792002199246596d86246a013a11892c68c9b7365d3b080661     && \
+    VERSION_DUPLICACY=2.7.2                                                                   && \
+    VERSION_DUPLICACY_WEB=1.6.3                                                               && \
                                                                                                  \
     # ------------------------------------------------------------------------------------------
                                                                                                  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,12 @@ RUN ARCHITECTURE=linux_x64                                                      
     echo "${SHA256_DUPLICACY_WEB}  ${_BIN_DUPLICACY_WEB}" | sha256sum -s -c -                 && \
     chmod +x $_BIN_DUPLICACY_WEB                                                              && \
                                                                                                  \
+    # link ~/.duplicacy-web to /etc/duplicacy
+    ln -s ${_DIR_CONF} ${_DIR_WEB}                                                            && \
+                                                                                                 \
     # create some dirs
     mkdir -p                                                                                     \
+      ${_DIR_CONF}                                                                               \
       ${_DIR_CACHE}/repositories                                                                 \
       ${_DIR_CACHE}/stats                                                                        \
       ${_DIR_WEB}/bin                                                                            \
@@ -73,10 +77,6 @@ RUN ARCHITECTURE=linux_x64                                                      
     ln -s /dev/stdout /var/log/duplicacy_web.log                                              && \
                                                                                                  \
     # stage the rest of the web directory
-    ln -s ${_DIR_CONF}/settings.json  ${_DIR_WEB}/settings.json                               && \
-    ln -s ${_DIR_CONF}/duplicacy.json ${_DIR_WEB}/duplicacy.json                              && \
-    ln -s ${_DIR_CONF}/licenses.json  ${_DIR_WEB}/licenses.json                               && \
-    ln -s ${_DIR_CONF}/filters        ${_DIR_WEB}/filters                                     && \
     ln -s ${_DIR_CACHE}/stats         ${_DIR_WEB}/stats
 
 EXPOSE 3875


### PR DESCRIPTION
Resolved by "flipping" the links between `/root/.duplicacy-web` and `/etc/duplicacy`. Instead of symlinking individual files files into `/root/.duplicacy-web`, `/root/.duplicacy-web` is now a symlink to `/etc/duplicacy`.